### PR TITLE
Improvements as per discussions and test plan notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This repository holds the source for this Specification, part of the family of [
 
 ### What does it do?
 
-Describes the specification for the NMOS Device Control protocol.
+Describes the specification for the NMOS Device Control & Monitoring Protocol.
 
 ### Why does it matter?
 
-Sets out the rules and requirements for implementing the NMOS Device Control protocol in devices and controllers.
+Sets out the rules and requirements for implementing the NMOS Device Control & Monitoring Protocol in devices and controllers.
 
 ### How does it work?
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# \[Work In Progress\] AMWA NMOS Control Procotol
+# \[Work In Progress\] AMWA NMOS Control & Monitoring Procotol
 
 [![Lint Status](https://github.com/AMWA-TV/is-12/workflows/Lint/badge.svg)](https://github.com/AMWA-TV/is-12/actions?query=workflow%3ALint)
 [![Render Status](https://github.com/AMWA-TV/is-12/workflows/Render/badge.svg)](https://github.com/AMWA-TV/is-12/actions?query=workflow%3ARender)

--- a/docs/Exploring the device model.md
+++ b/docs/Exploring the device model.md
@@ -1,9 +1,7 @@
-# Exploring the device tree
+# Exploring the device model
 
 All blocks ([NcBlock](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Blocks.html)) contain a members property which holds descriptions of all members (workers, blocks, managers etc.) contained.
 The members for any block can be obtained by invoking the generic Get method (1m1) for the property id (2p2).
-
-The device `root block` MUST always have the static `oid` of `1`. No other object or member must use the `oid` of `1` besides the root block.
 
 Example for calling the generic getter (1m1) on the root block to retrieve the members property (2p2)
 

--- a/docs/Exploring the device model.md
+++ b/docs/Exploring the device model.md
@@ -105,10 +105,10 @@ Example for calling FindMembersByPath (2m2) on the root block
         "level": 2,
         "index": 2
       },
-      "arguments":
-      {
+      "arguments": {
         "path": [
-          "ReceiverMonitor_01"
+          "receivers",
+          "monitor-01"
         ]
       }
     }
@@ -129,7 +129,7 @@ Example response from calling FindMembersByPath (2m2) on the root block
         "status": 200,
         "value": [
           {
-            "role": "ReceiverMonitor_01",
+            "role": "monitor-01",
             "oid": 11,
             "constantOid": true,
             "classId": [
@@ -138,7 +138,7 @@ Example response from calling FindMembersByPath (2m2) on the root block
               3
             ],
             "userLabel": "Receiver monitor 01",
-            "owner": 1,
+            "owner": 10,
             "description": "Receiver monitor worker"
           }
         ]

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,6 +1,6 @@
-# AMWA IS-12 NMOS Device Control Protocol \[Work In Progress\]
+# AMWA IS-12 NMOS Device Control & Monitoring Protocol \[Work In Progress\]
 
-This document aims to give a general description of the NMOS Device Control protocol. This protocol is compatible and adheres to the rules and requirements described in the NMOS Modeling architecture document and and is the way in which NMOS Control models (described in the NMOS Control Framework) can be exposed and consumed in a standardized way.
+This document aims to give a general description of the NMOS Device Control & Monitoring Protocol. This protocol is compatible and adheres to the rules and requirements described in the NMOS Modeling architecture document and and is the way in which NMOS Control models (described in the NMOS Control Framework) can be exposed and consumed in a standardized way.
 
 This document relies on previous familiarity with the following existing documents:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 ### Examples
 
 - [Sending commands](Sending%20commands.md)
-- [Exploring the device tree](Exploring%20the%20device%20tree.md)
+- [Exploring the device model](Exploring%20the%20device%20model.md)
 - [Subscribing to events](Subscribing%20to%20events.md)
 - [Class definition discovery](Class%20definition%20discovery.md)
 - [Data type definition discovery](Data%20type%20definition%20discovery.md)

--- a/docs/Subscribing to events.md
+++ b/docs/Subscribing to events.md
@@ -1,6 +1,6 @@
 # Subscribing to events
 
-A controller can subscribe to all OIDs it is interested in receiving notifications from by using the [SubscriptionMessage](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Protocol_messaging.html#subscription-message-type).
+A controller can subscribe to all OIDs it is interested in receiving notifications from by using the [Subscription](https://specs.amwa.tv/is-12/branches/v1.0-dev/docs/Protocol_messaging.html#subscription-message-type) message.
 
 Example message for subscribing to multiple OIDs.
 


### PR DESCRIPTION
- include "monitoring" when refering to the spec
- rename "Exploring the device tree" to "Exploring the device model"