### PR TITLE
Various improvements and clarifications

### DIFF
--- a/APIs/schemas/base-message.json
+++ b/APIs/schemas/base-message.json
@@ -4,15 +4,9 @@
   "description": "Base protocol message structure",
   "title": "Base protocol message",
   "required": [
-    "protocolVersion",
     "messageType"
   ],
   "properties": {
-    "protocolVersion": {
-      "description": "Protocol version number",
-      "type": "string",
-      "pattern": "^(\\d+\\.)?(\\d+\\.)?(\\d+)$"
-    },
     "messageType": {
       "description": "Protocol message type",
       "type": "integer",

--- a/APIs/schemas/error-message.json
+++ b/APIs/schemas/error-message.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Error protocol message structure - used by devices to return general error messages for example when incoming messages do not have protocolVersion, messageType, handles or contain invalid JSON",
+  "description": "Error protocol message structure - used by devices to return general error messages for example when incoming messages do not have messageType, handles or contain invalid JSON",
   "title": "Error protocol message",
   "allOf": [
     {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# \[Work In Progress\] AMWA NMOS Control & Monitoring Procotol
+# \[Work In Progress\] AMWA NMOS Control & Monitoring Protocol
 
 [![Lint Status](https://github.com/AMWA-TV/is-12/workflows/Lint/badge.svg)](https://github.com/AMWA-TV/is-12/actions?query=workflow%3ALint)
 [![Render Status](https://github.com/AMWA-TV/is-12/workflows/Render/badge.svg)](https://github.com/AMWA-TV/is-12/actions?query=workflow%3ARender)

--- a/docs/Class definition discovery.md
+++ b/docs/Class definition discovery.md
@@ -2,14 +2,13 @@
 
 [MS-05-02](https://specs.amwa.tv/ms-05-02) defines a class discovery mechanism in [NcClassManager](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Managers.html#class-manager) which can be used for discovering details of class definitions. Descriptors of all the classes can be retrieved by getting the value of property `controlClasses (3p1)`. Alternatively the `GetControlClass (3m1)` method can be used to return a single class descriptor. This requires the following arguments:
 
-* identity - of type [NcClassId](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncclassid)
+* classId - of type [NcClassId](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncclassid)
 * includeInherited - of type [NcBoolean](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#primitives) (if set the descriptor would contain all inherited elements)
 
 Example for calling GetControlClass (3m1) on the ClassManager (using the oid retrieved from the root block - e.g. ClassManager oid = 3) when wanting to retrieve the class definition for [NcReceiverMonitor (1,2,3)](https://specs.amwa.tv/nmos-control-feature-sets/branches/main/monitoring/#ncreceivermonitor)
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -21,7 +20,7 @@ Example for calling GetControlClass (3m1) on the ClassManager (using the oid ret
       },
       "arguments":
       {
-        "identity": [1, 2, 3],
+        "classId": [1, 2, 3],
         "includeInherited": true
       }
     }
@@ -33,7 +32,6 @@ Example response from calling GetControlClass (3m1) on the ClassManager for clas
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {
@@ -42,7 +40,7 @@ Example response from calling GetControlClass (3m1) on the ClassManager for clas
         "status": 200,
         "value": {
           "description": "NcReceiverMonitor class descriptor",
-          "identity": [
+          "classId": [
               1,
               2,
               3
@@ -393,6 +391,26 @@ Example response from calling GetControlClass (3m1) on the ClassManager for clas
                   "constraints": null
                 }
               ]
+            },
+            {
+              "description": "Get sequence length",
+              "id": {
+                "level": 1,
+                "index": 7
+              },
+              "name": "GetSequenceLength",
+              "resultDatatype": "NcMethodResultLength",
+              "parameters": [
+                {
+                  "description": "Property id",
+                  "name": "id",
+                  "typeName": "NcPropertyId",
+                  "isNullable": false,
+                  "isSequence": false,
+                  "constraints": null
+                }
+              ],
+              "isDeprecated": false
             }
           ],
           "events": [

--- a/docs/Data type definition discovery.md
+++ b/docs/Data type definition discovery.md
@@ -9,7 +9,6 @@ Example for calling GetDataType (3m2) on the ClassManager (using the oid retriev
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -32,7 +31,6 @@ Example response from calling GetDataType (3m2) on the ClassManager for data typ
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {

--- a/docs/Exploring the device model.md
+++ b/docs/Exploring the device model.md
@@ -7,7 +7,6 @@ Example for calling the generic getter (1m1) on the root block to retrieve the m
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -32,7 +31,6 @@ Example response from calling the generic getter (1m1) on the root block to retr
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {
@@ -95,7 +93,6 @@ Example for calling FindMembersByPath (2m2) on the root block
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -120,7 +117,6 @@ Example response from calling FindMembersByPath (2m2) on the root block
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {

--- a/docs/Protocol messaging.md
+++ b/docs/Protocol messaging.md
@@ -1,12 +1,10 @@
 # Protocol messaging
 
-All protocol messages MUST have the messageType property to indicate the type of the message (e.g. Command).
+All protocol messages MUST have the `messageType` property to indicate the type of the message (e.g. Command).
 
-* messageType - describes the message type (e.g. Command)
+When sending messages, each message MUST contain a `handle` numeric identifier. This is then used when responses are received from the device for matching the responses to the messages sent by the controller. The `handle` has no programmatic significance for the device.
 
-`Note`: When sending messages, each message MUST contain a `handle` numeric identifier. This is then used when responses are received from the device for matching the responses to the messages sent by the controller. The `handle` has no programmatic significance for the device.
-
-`Note`: All message results MUST return a response which inherits from the base [NcMethodResult](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresult) that contains a status of type [NcMethodStatus](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodstatus). If the method call encountered an error then the response result returned MUST inherit from [NcMethodResultError](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresulterror) and include an errorMessage of type [NcString](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#primitives).
+All message results MUST return a response which inherits from the base [NcMethodResult](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresult) that contains a status of type [NcMethodStatus](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodstatus). If the method call encountered an error then the response result returned MUST inherit from [NcMethodResultError](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresulterror) and include an errorMessage of type [NcString](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#primitives).
 
 Data types:
 

--- a/docs/Protocol messaging.md
+++ b/docs/Protocol messaging.md
@@ -1,8 +1,7 @@
 # Protocol messaging
 
-All protocol messages MUST have have the following 2 properties:
+All protocol messages MUST have have the following property:
 
-* protocolVersion - describes the version of this protocol (e.g. 1.0.0)
 * messageType - describes the message type (e.g. Command)
 
 `Note`: When sending messages, each message MUST contain a `handle` numeric identifier. This is then used when responses are received from the device for matching the responses to the messages sent by the controller. The `handle` has no programmatic significance for the device.
@@ -13,7 +12,6 @@ Data types:
 
 | Property                   | JSON representation                       |
 | -------------------------- | ----------------------------------------- |
-| protocolVersion            | String value of the protocol version      |
 | messageType                | Integer enum value as described below     |
 | handle                     | Integer value of the message handle       |
 
@@ -47,9 +45,16 @@ Each message MUST have the following:
 * methodId - unique method ID specified as the level and index of the method inside the class.
 * arguments - dictionary of arguments where the keys are the argument names and the values are their desired values (only needed if the method requires arguments)
 
-Commands MUST be responded to by devices using the `CommandResponse` messageType and the matching `handle` for each message.
+Commands MUST be responded to by devices using the [CommandResponse](#command-response-message-type) messageType and the matching `handle` for each message.
 
-All command results inherit from the base [NcMethodResult](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresult). This means all results MUST have a `status` property.
+## Command response message type
+
+Command responses are clearly distinguished using the `CommandResponse` messageType.
+Multiple messages MAY be sent in a `CommandResponse`.
+Each message MUST have the following:
+
+* handle - numeric message identification used for pairing the response with the associated command
+* result - result returned by the command which inherits from the base [NcMethodResult](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresult). This means all results MUST have a `status` property.
 
 When a method call encounters an error the return MUST be [NcMethodResultError](https://specs.amwa.tv/ms-05-02/branches/v1.0-dev/docs/Framework.html#ncmethodresulterror) or a derived datatype.
 
@@ -68,7 +73,6 @@ Each message MUST have the following:
 Subscription messages are clearly distinguished using the `Subscription` messageType.
 Each message MUST have the following:
 
-* protocolVersion - describes the version of this protocol (e.g. 1.0.0)
 * messageType - describes the message type
 * subscriptions - Array of OIDs desired for subscription
 
@@ -79,7 +83,6 @@ Subscription messages MUST be responded to by devices using the `SubscriptionRes
 Subscription response messages are clearly distinguished using the `SubscriptionResponse` messageType.
 Each message MUST have the following:
 
-* protocolVersion - describes the version of this protocol (e.g. 1.0.0)
 * messageType - describes the message type
 * subscriptions - Array of OIDs which have successfully been added to the subscription list
 
@@ -89,7 +92,6 @@ Here is one example.
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 4,
   "subscriptions": [
     1,
@@ -107,9 +109,8 @@ This allows controllers to know which items they have successfully subscribed to
 Error messages are clearly distinguished using the `Error` messageType.
 Each message MUST have the following:
 
-* protocolVersion - describes the version of this protocol (e.g. 1.0.0)
 * messageType - describes the message type
 * status - status of the message response. Must include the numeric values for NcMethodStatus or other types which inherit from it.
 * errorMessage - error details associated with the failure
 
-Error messages MUST be used by devices to return general error messages when more specific responses cannot be returned using the `CommandResponse` message (for example when incoming messages do not have protocolVersion, messageType, handles or contain invalid JSON).
+Error messages MUST be used by devices to return general error messages when more specific responses cannot be returned using the `CommandResponse` message (for example when incoming messages do not have messageType, handles or contain invalid JSON).

--- a/docs/Protocol messaging.md
+++ b/docs/Protocol messaging.md
@@ -1,6 +1,6 @@
 # Protocol messaging
 
-All protocol messages MUST have have the following property:
+All protocol messages MUST have the messageType property to indicate the type of the message (e.g. Command).
 
 * messageType - describes the message type (e.g. Command)
 

--- a/docs/Sending commands.md
+++ b/docs/Sending commands.md
@@ -4,7 +4,6 @@ Example for setting the user label (1p6) on any [NcObject](https://specs.amwa.tv
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -30,7 +29,6 @@ Example response for setting the user label (1p6) on any [NcObject](https://spec
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {
@@ -47,7 +45,6 @@ Example command for retrieving the classId (1p1) on any [NcObject](https://specs
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 0,
   "commands": [
     {
@@ -72,7 +69,6 @@ Example response for retrieving the classId (1p1) on any [NcObject](https://spec
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 1,
   "responses": [
     {

--- a/docs/Subscribing to events.md
+++ b/docs/Subscribing to events.md
@@ -6,7 +6,6 @@ Example message for subscribing to multiple OIDs.
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 3,
   "subscriptions": [
     1,
@@ -21,7 +20,6 @@ Example [SubscriptionResponse](https://specs.amwa.tv/is-12/branches/v1.0-dev/doc
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 4,
   "subscriptions": [
     1,
@@ -37,7 +35,6 @@ Example notification for the PropertyChanged event (1e1) when the `userLabel` pr
 
 ```json
 {
-  "protocolVersion": "1.0.0",
   "messageType": 2,
   "notifications": [
     {


### PR DESCRIPTION
- protocolVersion field removed from IS-12
- add specific section for "Command response message type" classId naming:
- GetControlClass (identity -> classId)
- NcClassDescriptor (identity -> classId)
- correct JSON examples